### PR TITLE
Adhere to PEP518

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["cython", "setuptools", "wheel", "numpy", "scipy"]


### PR DESCRIPTION
This allows this package to work correctly on ReadTheDocs by specifying cython as a build-time requirement, added through `pyproject.toml`.

https://www.python.org/dev/peps/pep-0518/