### PR TITLE
Specify Cython version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "cython", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=61.0.0", "wheel", "cython==0.29", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
fix(pyproject): Specified version number from Cython in pyproject.toml file.

cpdef is depreciated in Cython versions following 0.29, causing installation to fail.