### PR TITLE
fix: Use importlib for 3.12+ compatibility.

### DIFF
--- a/.github/workflows/install_doctest_lint_typecheck.yml
+++ b/.github/workflows/install_doctest_lint_typecheck.yml
@@ -11,7 +11,7 @@ jobs:
       # You can use PyPy versions in python-version.
       # For example, pypy2.7 and pypy3.9
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v3

--- a/sorted_nearest/__init__.py
+++ b/sorted_nearest/__init__.py
@@ -1,4 +1,4 @@
-import pkg_resources
+from importlib.metadata import version
 
 from sorted_nearest.src.annotate_clusters import annotate_clusters  # type: ignore  # NOQA: F401
 from sorted_nearest.src.cluster_by import cluster_by  # type: ignore  # NOQA: F401
@@ -19,4 +19,4 @@ from sorted_nearest.src.sorted_nearest import (  # type: ignore  # NOQA: F401
 from sorted_nearest.src.tiles import maketiles  # type: ignore  # NOQA: F401
 from sorted_nearest.src.windows import makewindows  # type: ignore  # NOQA: F401
 
-__version__ = pkg_resources.get_distribution("sorted_nearest").version
+__version__ = version("sorted_nearest")


### PR DESCRIPTION
Hopefully solves this issue:
https://github.com/pyranges/sorted_nearest/issues/10

I have tested Python 3.13.2 and 3.8.18 as follows:

    python3 -c "import sorted_nearest; print(sorted_nearest.__version__)"

In both cases it is able to print something ("0.0.40").